### PR TITLE
perf(client): webpack と NODE_ENV を環境に応じた動的設定に変更

### DIFF
--- a/application/client/babel.config.js
+++ b/application/client/babel.config.js
@@ -1,19 +1,20 @@
+const isProd = process.env.NODE_ENV === "production";
+
 module.exports = {
   presets: [
     ["@babel/preset-typescript"],
     [
       "@babel/preset-env",
       {
-        targets: "ie 11",
-        corejs: "3",
-        modules: "commonjs",
+        targets: "defaults",
+        modules: false,
         useBuiltIns: false,
       },
     ],
     [
       "@babel/preset-react",
       {
-        development: true,
+        development: !isProd,
         runtime: "automatic",
       },
     ],

--- a/application/client/package.json
+++ b/application/client/package.json
@@ -5,7 +5,8 @@
   "license": "MPL-2.0",
   "author": "CyberAgent, Inc.",
   "scripts": {
-    "build": "NODE_ENV=development webpack",
+    "dev": "webpack serve",
+    "build": "NODE_ENV=production webpack",
     "typecheck": "tsc"
   },
   "dependencies": {

--- a/application/client/src/index.html
+++ b/application/client/src/index.html
@@ -4,8 +4,6 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CaX</title>
-    <script src="/scripts/main.js"></script>
-    <link rel="stylesheet" href="/styles/main.css" />
   </head>
   <body class="bg-cax-canvas text-cax-text">
     <div id="app"></div>

--- a/application/client/webpack.config.js
+++ b/application/client/webpack.config.js
@@ -29,8 +29,6 @@ const config = {
   devtool: isProd ? false : "eval-source-map",
   entry: {
     main: [
-      "core-js",
-      "regenerator-runtime/runtime",
       "jquery-binarytransport",
       path.resolve(SRC_PATH, "./index.css"),
       path.resolve(SRC_PATH, "./buildinfo.ts"),
@@ -60,9 +58,9 @@ const config = {
     ],
   },
   output: {
-    chunkFilename: "scripts/chunk-[contenthash].js",
+    chunkFilename: isProd ? "scripts/chunk-[contenthash].js" : "scripts/chunk-[id].js",
     chunkFormat: false,
-    filename: "scripts/[name].js",
+    filename: isProd ? "scripts/[name]-[contenthash].js" : "scripts/[name].js",
     path: DIST_PATH,
     publicPath: "auto",
     clean: true,
@@ -81,7 +79,7 @@ const config = {
       NODE_ENV: isProd ? "production" : "development",
     }),
     new MiniCssExtractPlugin({
-      filename: "styles/[name].css",
+      filename: isProd ? "styles/[name]-[contenthash].css" : "styles/[name].css",
     }),
     new CopyWebpackPlugin({
       patterns: [
@@ -92,7 +90,8 @@ const config = {
       ],
     }),
     new HtmlWebpackPlugin({
-      inject: false,
+      inject: "body",
+      scriptLoading: "defer",
       template: path.resolve(SRC_PATH, "./index.html"),
     }),
   ],
@@ -136,7 +135,7 @@ const config = {
     providedExports: false,
     sideEffects: false,
   },
-  cache: false,
+  cache: !isProd,
   ignoreWarnings: [
     {
       module: /@ffmpeg/,

--- a/application/client/webpack.config.js
+++ b/application/client/webpack.config.js
@@ -10,6 +10,7 @@ const SRC_PATH = path.resolve(__dirname, "./src");
 const PUBLIC_PATH = path.resolve(__dirname, "../public");
 const UPLOAD_PATH = path.resolve(__dirname, "../upload");
 const DIST_PATH = path.resolve(__dirname, "../dist");
+const isProd = process.env.NODE_ENV === "production";
 
 /** @type {import('webpack').Configuration} */
 const config = {
@@ -25,7 +26,7 @@ const config = {
     ],
     static: [PUBLIC_PATH, UPLOAD_PATH],
   },
-  devtool: "inline-source-map",
+  devtool: isProd ? false : "eval-source-map",
   entry: {
     main: [
       "core-js",
@@ -36,7 +37,7 @@ const config = {
       path.resolve(SRC_PATH, "./index.tsx"),
     ],
   },
-  mode: "none",
+  mode: isProd ? "production" : "development",
   module: {
     rules: [
       {
@@ -77,7 +78,7 @@ const config = {
       BUILD_DATE: new Date().toISOString(),
       // Heroku では SOURCE_VERSION 環境変数から commit hash を参照できます
       COMMIT_HASH: process.env.SOURCE_VERSION || "",
-      NODE_ENV: "development",
+      NODE_ENV: isProd ? "production" : "development",
     }),
     new MiniCssExtractPlugin({
       filename: "styles/[name].css",
@@ -127,7 +128,7 @@ const config = {
       url: false,
     },
   },
-  optimization: {
+  optimization: isProd ? {} : {
     minimize: false,
     splitChunks: false,
     concatenateModules: false,

--- a/application/package.json
+++ b/application/package.json
@@ -5,6 +5,7 @@
   "author": "CyberAgent, Inc.",
   "type": "module",
   "scripts": {
+    "dev": "pnpm --filter @web-speed-hackathon-2026/server dev & pnpm --filter @web-speed-hackathon-2026/client dev",
     "build": "pnpm --filter @web-speed-hackathon-2026/client build",
     "start": "pnpm --filter @web-speed-hackathon-2026/server start",
     "typecheck": "pnpm run --recursive typecheck",

--- a/application/server/package.json
+++ b/application/server/package.json
@@ -7,6 +7,7 @@
   "type": "module",
   "main": "src/index.js",
   "scripts": {
+    "dev": "tsx --watch src/index.ts",
     "start": "tsx src/index.ts",
     "typecheck": "tsc --noEmit",
     "seed:generate": "tsx ./scripts/generateSeeds.ts",

--- a/application/server/src/app.ts
+++ b/application/server/src/app.ts
@@ -14,10 +14,7 @@ app.use(bodyParser.json());
 app.use(bodyParser.raw({ limit: "10mb" }));
 
 app.use((_req, res, next) => {
-  res.header({
-    "Cache-Control": "max-age=0, no-transform",
-    Connection: "close",
-  });
+  res.header({ Connection: "close" });
   return next();
 });
 

--- a/application/server/src/routes/static.ts
+++ b/application/server/src/routes/static.ts
@@ -15,21 +15,25 @@ staticRouter.use(history());
 
 staticRouter.use(
   serveStatic(UPLOAD_PATH, {
-    etag: false,
-    lastModified: false,
+    etag: true,
+    lastModified: true,
+    maxAge: "1d",
   }),
 );
 
 staticRouter.use(
   serveStatic(PUBLIC_PATH, {
-    etag: false,
-    lastModified: false,
+    etag: true,
+    lastModified: true,
+    maxAge: "7d",
   }),
 );
 
 staticRouter.use(
   serveStatic(CLIENT_DIST_PATH, {
-    etag: false,
-    lastModified: false,
+    etag: true,
+    lastModified: true,
+    maxAge: "1y",
+    immutable: true,
   }),
 );


### PR DESCRIPTION
## ボトルネック
- webpack が `mode: "none"` 固定で、minification・tree shaking・scope hoisting が全て無効
- `NODE_ENV=development` 固定でReactの開発モード警告・チェックが有効
- Babelが `targets: "ie 11"` + `modules: "commonjs"` で、不要なポリフィル挿入とESM tree shakingの無効化
- `inline-source-map` で巨大なインラインソースマップがバンドルに埋め込まれていた
- エントリに `core-js` と `regenerator-runtime/runtime` が含まれていた
- HtmlWebpackPlugin が `inject: false` で、index.html に手動でscriptタグを記述していた
- 静的ファイルに `Cache-Control: max-age=0` / `ETag: false` / `lastModified: false` が設定されていた

## 対策
- webpack `mode` を環境変数に応じて `production` / `development` に動的切替
- `NODE_ENV` を本番で `production` に設定
- Babel: `targets: "ie 11"` → `"defaults"`, `modules: "commonjs"` → `false`（ESM出力）
- `core-js` / `regenerator-runtime` をエントリから削除
- devtool: `inline-source-map` → 本番は `false` / 開発は `eval-source-map`
- output に `[contenthash]` を追加しキャッシュバスティング有効化
- HtmlWebpackPlugin: `inject: "body"` + `scriptLoading: "defer"` に変更
- サーバー: `Cache-Control: max-age=0, no-transform` を削除
- 静的ファイル: `etag: true` / `lastModified: true` / upload `maxAge: "1d"` / public `maxAge: "7d"` / dist `maxAge: "1y"` + `immutable: true`

## 効果
- JSバンドルの大幅圧縮 + Tree Shaking有効化
- ソースマップの外部化（バンドルサイズ削減）
- リピートアクセスのキャッシュ効率大幅改善
- React本番最適化