### PR TITLE
Perf/webpack chunk

### DIFF
--- a/application/client/webpack.config.js
+++ b/application/client/webpack.config.js
@@ -59,7 +59,6 @@ const config = {
   },
   output: {
     chunkFilename: isProd ? "scripts/chunk-[contenthash].js" : "scripts/chunk-[id].js",
-    chunkFormat: false,
     filename: isProd ? "scripts/[name]-[contenthash].js" : "scripts/[name].js",
     path: DIST_PATH,
     publicPath: "auto",
@@ -127,14 +126,18 @@ const config = {
       url: false,
     },
   },
-  optimization: isProd ? {} : {
-    minimize: false,
-    splitChunks: false,
-    concatenateModules: false,
-    usedExports: false,
-    providedExports: false,
-    sideEffects: false,
-  },
+  optimization: isProd
+    ? {
+      splitChunks: { chunks: all },
+    }
+    : {
+      minimize: false,
+      splitChunks: false,
+      concatenateModules: false,
+      usedExports: false,
+      providedExports: false,
+      sideEffects: false,
+    },
   cache: !isProd,
   ignoreWarnings: [
     {

--- a/application/client/webpack.config.js
+++ b/application/client/webpack.config.js
@@ -29,7 +29,6 @@ const config = {
   devtool: isProd ? false : "eval-source-map",
   entry: {
     main: [
-      "jquery-binarytransport",
       path.resolve(SRC_PATH, "./index.css"),
       path.resolve(SRC_PATH, "./buildinfo.ts"),
       path.resolve(SRC_PATH, "./index.tsx"),
@@ -66,10 +65,8 @@ const config = {
   },
   plugins: [
     new webpack.ProvidePlugin({
-      $: "jquery",
       AudioContext: ["standardized-audio-context", "AudioContext"],
       Buffer: ["buffer", "Buffer"],
-      "window.jQuery": "jquery",
     }),
     new webpack.EnvironmentPlugin({
       BUILD_DATE: new Date().toISOString(),


### PR DESCRIPTION
## ボトルネック
webpack の `splitChunks` が `false` で、全コードが1つの巨大バンドルに同梱されていた。jQuery関連も不要な形でバンドルに含まれていた。

## 対策
- webpack の production 時に `splitChunks: { chunks: "all" }` を有効化
- エントリから `jquery-binarytransport` を削除
- `chunkFormat: false` を削除
- `webpack.ProvidePlugin` から jQuery 関連(`$`, `window.jQuery`) を削除

## 効果
- ベンダーライブラリの自動分離でキャッシュ効率向上
- jQuery関連のグローバル注入を除去