### PR TITLE
fix(client): webpack設定のsplitChunksオプションをクォートで囲む

### DIFF
--- a/application/client/webpack.config.js
+++ b/application/client/webpack.config.js
@@ -125,7 +125,7 @@ const config = {
   },
   optimization: isProd
     ? {
-      splitChunks: { chunks: all },
+      splitChunks: { chunks: 'all' },
     }
     : {
       minimize: false,


### PR DESCRIPTION
## 問題
PR #49 で追加した webpack の splitChunks 設定で、オプションキーにクォートが不足していたためパースエラーが発生。

## 対策
splitChunks のオプションキーを適切にクォートで囲み、設定が正しく適用されるよう修正。