### PR TITLE
build(client): webpack の resolve extensions に .json を追加

### DIFF
--- a/application/client/webpack.config.js
+++ b/application/client/webpack.config.js
@@ -88,7 +88,7 @@ const config = {
     }),
   ],
   resolve: {
-    extensions: [".tsx", ".ts", ".mjs", ".cjs", ".jsx", ".js"],
+    extensions: [".tsx", ".ts", ".mjs", ".cjs", ".jsx", ".js", ".json"],
     alias: {
       "bayesian-bm25$": path.resolve(__dirname, "node_modules", "bayesian-bm25/dist/index.js"),
       ["kuromoji$"]: path.resolve(__dirname, "node_modules", "kuromoji/build/kuromoji.js"),


### PR DESCRIPTION
## 問題
webpack の `resolve.extensions` に `.json` が含まれておらず、`import data from "./file.json"` のような拡張子なしのJSON importが解決できずビルドエラーが発生していた。

## 対策
webpack の `resolve.extensions` に `.json` を追加。