### PR TITLE
fix(client): negaposi辞書をプロジェクト内にバンドル

### DIFF
--- a/application/client/webpack.config.js
+++ b/application/client/webpack.config.js
@@ -92,6 +92,7 @@ const config = {
     alias: {
       "bayesian-bm25$": path.resolve(__dirname, "node_modules", "bayesian-bm25/dist/index.js"),
       ["kuromoji$"]: path.resolve(__dirname, "node_modules", "kuromoji/build/kuromoji.js"),
+      "../dict/pn_ja.dic.json$": path.resolve(SRC_PATH, "data/pn_ja.dic.json"),
     },
     fallback: {
       fs: false,


### PR DESCRIPTION
## ボトルネック
negaposi-analyzer-ja の感情極性辞書が `postinstall` スクリプトでダウンロードされる仕組みだったが、Docker環境でダウンロードが失敗していた。

## 対策
- 辞書JSON (`pn_ja.dic.json`) を `client/src/data/` に配置
- webpack alias で辞書のインポートパスをプロジェクト内ファイルに解決

## 効果
- Docker環境でも辞書が確実に利用可能になった