### PR TITLE
fix: pnpm overridesをpackage.jsonに追加しlockfileとの整合性を修正

### DIFF
--- a/application/package.json
+++ b/application/package.json
@@ -25,6 +25,10 @@
     "onlyBuiltDependencies": [
       "ffmpeg-static",
       "sharp"
-    ]
+    ],
+    "overrides": {
+      "gifler>bluebird": "3.7.2",
+      "gifler>omggif": "1.0.10"
+    }
   }
 }


### PR DESCRIPTION
## ボトルネック
lockfile にのみ overrides が記録され、`package.json` に定義がなかったため、Docker内の `pnpm install --frozen-lockfile` が `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` エラーで失敗していた。

## 対策
- `package.json` に `pnpm.overrides` セクションを追加し、lockfile との整合性を確保

## 効果
- Docker環境での `pnpm install --frozen-lockfile` が正常に完了するようになった