### PR TITLE
fix(client): publicPathをautoから/に変更しサブパスでのアセット読み込みを修正

### DIFF
--- a/application/client/webpack.config.js
+++ b/application/client/webpack.config.js
@@ -56,7 +56,7 @@ const config = {
     chunkFilename: isProd ? "scripts/chunk-[contenthash].js" : "scripts/chunk-[id].js",
     filename: isProd ? "scripts/[name]-[contenthash].js" : "scripts/[name].js",
     path: DIST_PATH,
-    publicPath: "auto",
+    publicPath: "/",
     clean: true,
   },
   plugins: [


### PR DESCRIPTION
## ボトルネック
webpack の `publicPath: "auto"` が設定されていたため、`/posts/:id` などのサブパスでページリロードすると CSS/JS が相対パスで解決され 404 エラーになっていた。

## 対策
- `publicPath` を `"auto"` から `"/"` に変更し、常にルート相対パスでアセットを参照

## 効果
- サブパスでのページリロード時にアセットが正しく読み込まれるようになった