### PR TITLE
perf(client): AspectRatioBoxをCSS aspect-ratioに置き換え

### DIFF
--- a/application/client/src/components/foundation/AspectRatioBox.tsx
+++ b/application/client/src/components/foundation/AspectRatioBox.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useEffect, useRef, useState } from "react";
+import { ReactNode } from "react";
 
 interface Props {
   aspectHeight: number;
@@ -10,28 +10,9 @@ interface Props {
  * 親要素の横幅を基準にして、指定したアスペクト比のブロック要素を作ります
  */
 export const AspectRatioBox = ({ aspectHeight, aspectWidth, children }: Props) => {
-  const ref = useRef<HTMLDivElement>(null);
-  const [clientHeight, setClientHeight] = useState(0);
-
-  useEffect(() => {
-    // clientWidth とアスペクト比から clientHeight を計算する
-    function calcStyle() {
-      const clientWidth = ref.current?.clientWidth ?? 0;
-      setClientHeight((clientWidth / aspectWidth) * aspectHeight);
-    }
-    setTimeout(() => calcStyle(), 500);
-
-    // ウィンドウサイズが変わるたびに計算する
-    window.addEventListener("resize", calcStyle, { passive: false });
-    return () => {
-      window.removeEventListener("resize", calcStyle);
-    };
-  }, [aspectHeight, aspectWidth]);
-
   return (
-    <div ref={ref} className="relative h-1 w-full" style={{ height: clientHeight }}>
-      {/* 高さが計算できるまで render しない */}
-      {clientHeight !== 0 ? <div className="absolute inset-0">{children}</div> : null}
+    <div className="relative w-full" style={{ aspectRatio: `${aspectWidth} / ${aspectHeight}` }}>
+      <div className="absolute inset-0">{children}</div>
     </div>
   );
 };


### PR DESCRIPTION
## ボトルネック
`AspectRatioBox` コンポーネントがJSで500msの `setTimeout` + `resize` イベントリスナーを使ってアスペクト比を計算していた。`clientHeight !== 0` ガードで子要素の描画もブロックされていた。

## 対策
- JS計算を廃止し、CSS `aspect-ratio` プロパティで即座にレイアウト確定
- 子要素の描画ブロック（`clientHeight !== 0` ガード）も除去

## 効果
- 500ms遅延の除去
- リフロー削減（JSレイアウト計算が不要に）
- 子要素が即座に描画されるように