### PR TITLE
perf(client): createTranslatorを動的インポートに変更しバンドルサイズ削減

### DIFF
--- a/application/client/src/components/post/TranslatableText.tsx
+++ b/application/client/src/components/post/TranslatableText.tsx
@@ -1,7 +1,5 @@
 import { useCallback, useState } from "react";
 
-import { createTranslator } from "@web-speed-hackathon-2026/client/src/utils/create_translator";
-
 type State =
   | { type: "idle"; text: string }
   | { type: "loading" }
@@ -20,6 +18,9 @@ export const TranslatableText = ({ text }: Props) => {
         (async () => {
           updateState({ type: "loading" });
           try {
+            const { createTranslator } = await import(
+              "@web-speed-hackathon-2026/client/src/utils/create_translator"
+            );
             using translator = await createTranslator({
               sourceLanguage: "ja",
               targetLanguage: "en",


### PR DESCRIPTION
## ボトルネック
`create_translator.ts` が静的インポートで読み込まれており、翻訳に使う大量のライブラリ（langs / json-repair-js / common-tags / @mlc-ai/web-llm）が初期バンドルに含まれていた。翻訳機能は翻訳ボタンクリック時にのみ必要。

## 対策
- `CreateMLCEngine` の import を静的 `import` から動的 `import()` に変更し、翻訳ボタンクリック時にのみ読み込むよう変更

## 効果
- @mlc-ai/web-llm 等の大量ライブラリが初期バンドルから除外