### PR TITLE
fix: 検索機能のReDoS脆弱性を修正

### DIFF
--- a/application/client/src/search/services.ts
+++ b/application/client/src/search/services.ts
@@ -10,37 +10,28 @@ export const sanitizeSearchText = (input: string): string => {
 };
 
 export const parseSearchQuery = (query: string) => {
-  const sincePattern = /since:((\d|\d\d|\d\d\d\d-\d\d-\d\d)+)+$/;
-  const untilPattern = /until:((\d|\d\d|\d\d\d\d-\d\d-\d\d)+)+$/;
-
   const sincePart = query.match(/since:[^\s]*/)?.[0] || "";
   const untilPart = query.match(/until:[^\s]*/)?.[0] || "";
 
-  const sinceMatch = sincePattern.exec(sincePart);
-  const untilMatch = untilPattern.exec(untilPart);
+  const extractDate = (s: string) => {
+    const m = /(\d{4}-\d{2}-\d{2})/.exec(s);
+    return m ? m[1]! : null;
+  };
 
   const keywords = query
-    .replace(/since:.*(\d{4}-\d{2}-\d{2}).*/g, "")
-    .replace(/until:.*(\d{4}-\d{2}-\d{2}).*/g, "")
+    .replace(/since:[^\s]*/g, "")
+    .replace(/until:[^\s]*/g, "")
     .trim();
-
-  const extractDate = (s: string | null) => {
-    if (!s) return null;
-    const m = /(\d{4}-\d{2}-\d{2})/.exec(s);
-    return m ? m[1] : null;
-  };
 
   return {
     keywords,
-    sinceDate: extractDate(sinceMatch ? sinceMatch[1]! : null),
-    untilDate: extractDate(untilMatch ? untilMatch[1]! : null),
+    sinceDate: extractDate(sincePart),
+    untilDate: extractDate(untilPart),
   };
 };
 
 export const isValidDate = (dateStr: string): boolean => {
-  const slowDateLike = /^(\d+)+-(\d+)+-(\d+)+$/;
-  if (!slowDateLike.test(dateStr)) return false;
-
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(dateStr)) return false;
   const date = new Date(dateStr);
   return !Number.isNaN(date.getTime());
 };

--- a/application/server/src/routes/api/search.ts
+++ b/application/server/src/routes/api/search.ts
@@ -1,7 +1,7 @@
 import { Router } from "express";
 import { Op } from "sequelize";
 
-import { Post } from "@web-speed-hackathon-2026/server/src/models";
+import { Post, User } from "@web-speed-hackathon-2026/server/src/models";
 import { parseSearchQuery } from "@web-speed-hackathon-2026/server/src/utils/parse_search_query.js";
 
 export const searchRouter = Router();
@@ -53,8 +53,8 @@ searchRouter.get("/search", async (req, res) => {
     postsByUser = await Post.unscoped().findAll({
       include: [
         {
-          association: "user",
-          attributes: { exclude: ["profileImageId"] },
+          model: User.unscoped(),
+          as: "user",
           include: [{ association: "profileImage" }],
           required: true,
           where: {
@@ -76,7 +76,6 @@ searchRouter.get("/search", async (req, res) => {
       limit,
       offset,
       where: dateWhere,
-      subQuery: false,
     });
   }
 
@@ -92,7 +91,8 @@ searchRouter.get("/search", async (req, res) => {
 
   mergedPosts.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
 
-  const result = mergedPosts.slice(offset || 0, (offset || 0) + (limit || mergedPosts.length));
+  // offset/limit は既に各DBクエリで適用済みなので、mergedではlimitのみ適用
+  const result = limit ? mergedPosts.slice(0, limit) : mergedPosts;
 
   return res.status(200).type("application/json").send(result);
 });


### PR DESCRIPTION
## ボトルネック
- `parseSearchQuery` の `sincePattern`/`untilPattern` が `((\d|\d\d|\d\d\d\d-\d\d-\d\d)+)+$` という ReDoS 脆弱性を持つ正規表現だった
- `isValidDate` も `/^(\d+)+-(\d+)+-(\d+)+$/` で同様に脆弱
- 計測ツールが `"0".repeat(20) + "x"` を入力してReDoSをテストしており、redux-form の validate がキー入力のたびに走るためメインスレッドがフリーズ

## 対策
- 正規表現を安全なパターン `/^\d{4}-\d{2}-\d{2}$/` に置換
- サーバー側の検索APIで不要な `subQuery: false` を削除し、結果のスライス処理を修正

## 効果
- 悪意ある入力（`"0".repeat(20) + "x"`）でもフリーズしなくなった
- 計測ツールの検索フローテストが通るようになった