### PR TITLE
fix: DM送信・画像投稿フローの計測失敗を修正

### DIFF
--- a/application/client/src/containers/NewDirectMessageModalContainer.tsx
+++ b/application/client/src/containers/NewDirectMessageModalContainer.tsx
@@ -36,6 +36,7 @@ export const NewDirectMessageModalContainer = ({ id }: Props) => {
         const conversation = await sendJSON<Models.DirectMessageConversation>(`/api/v1/dm`, {
           peerId: user.id,
         });
+        ref.current?.close();
         navigate(`/dm/${conversation.id}`);
       } catch {
         throw new SubmissionError({

--- a/application/server/src/routes/api/image.ts
+++ b/application/server/src/routes/api/image.ts
@@ -21,13 +21,13 @@ imageRouter.post("/images", async (req, res) => {
     throw new httpErrors.BadRequest();
   }
 
-  const converted = await convertImage(req.body);
+  const { buffer, alt } = await convertImage(req.body);
 
   const imageId = uuidv4();
 
   const filePath = path.resolve(UPLOAD_PATH, `./images/${imageId}.${EXTENSION}`);
   await fs.mkdir(path.resolve(UPLOAD_PATH, "images"), { recursive: true });
-  await fs.writeFile(filePath, converted);
+  await fs.writeFile(filePath, buffer);
 
-  return res.status(200).type("application/json").send({ id: imageId });
+  return res.status(200).type("application/json").send({ id: imageId, alt });
 });

--- a/application/server/src/utils/convert_image.ts
+++ b/application/server/src/utils/convert_image.ts
@@ -1,7 +1,12 @@
 import exifReader from "exif-reader";
 import sharp from "sharp";
 
-export async function convertImage(input: Buffer): Promise<Buffer> {
+interface ConvertImageResult {
+  buffer: Buffer;
+  alt: string;
+}
+
+export async function convertImage(input: Buffer): Promise<ConvertImageResult> {
   let imageDescription: string | undefined;
 
   try {
@@ -25,5 +30,5 @@ export async function convertImage(input: Buffer): Promise<Buffer> {
     });
   }
 
-  return await pipeline.toBuffer();
+  return { buffer: await pipeline.toBuffer(), alt: imageDescription ?? "" };
 }


### PR DESCRIPTION
## ボトルネック
- DM送信フロー: `NewDirectMessageModalContainer` でモーダルを閉じずに `navigate()` していたため、DMスレッドへの遷移が計測ツールに検出されなかった
- 画像投稿フロー: EXIF `ImageDescription` をAPIレスポンスに含めていなかったため、`<img alt="">` となりテストの `getByAltText()` が失敗していた

## 対策
- DM送信: `navigate()` 前に `ref.current?.close()` でモーダルを閉じるよう追加
- 画像投稿: `convertImage` の戻り値に alt を追加し、`POST /api/v1/images` のレスポンスに含めるよう修正

## 効果
- スコアリングツールのDM送信フローが計測可能に
- スコアリングツールの投稿フローが計測可能に