### PR TITLE
perf: KaTeXチャンク(1.3MB)のホームページ初期ロードを排除

### DIFF
--- a/application/client/vite.config.ts
+++ b/application/client/vite.config.ts
@@ -67,6 +67,7 @@ export default defineConfig({
   },
 
   build: {
+    modulePreload: false,
     outDir: path.resolve(__dirname, "../dist"),
     emptyOutDir: true,
     rollupOptions: {
@@ -80,6 +81,10 @@ export default defineConfig({
           return "assets/[name]-[hash][extname]";
         },
         manualChunks(id) {
+          // Vite preload helper → vendor-react (always loaded)
+          if (id.includes("vite/preload-helper")) {
+            return "vendor-react";
+          }
           // React core + router + redux
           if (id.includes("node_modules/react/") || id.includes("node_modules/react-dom/") || id.includes("node_modules/react-router") || id.includes("node_modules/react-redux") || id.includes("node_modules/redux") || id.includes("node_modules/@reduxjs")) {
             return "vendor-react";


### PR DESCRIPTION
## ボトルネック
Viteのプリロードヘルパーが vendor-markdown チャンクに配置されていたため、全ページで KaTeX(1.3MB) が静的インポートされていた。ホームページでもCrok専用のMarkdown/KaTeXが読み込まれる状態。

## 対策
- `manualChunks` でプリロードヘルパーを vendor-react チャンクに強制配置
- `modulePreload: false` でプリロードリンクも無効化

## 効果
- ホームページ初期JS: **1,743KB → 389KB（78%削減）**
- KaTeX/Markdownチャンクが必要なページ（Crok）でのみ読み込まれるように