### PR TITLE
fix: initializeSequelizeのコネクション競合を修正

### DIFF
--- a/application/server/src/sequelize.ts
+++ b/application/server/src/sequelize.ts
@@ -11,8 +11,6 @@ let _sequelize: Sequelize | null = null;
 
 export async function initializeSequelize() {
   const prevSequelize = _sequelize;
-  _sequelize = null;
-  await prevSequelize?.close();
 
   const TEMP_PATH = path.resolve(
     await fs.mkdtemp(path.resolve(os.tmpdir(), "./wsh-")),
@@ -26,4 +24,7 @@ export async function initializeSequelize() {
     storage: TEMP_PATH,
   });
   initModels(_sequelize);
+
+  // 新しいコネクションが準備できてから古いものを閉じる
+  await prevSequelize?.close();
 }


### PR DESCRIPTION
## ボトルネック
`POST /api/v1/initialize` 実行時、古いSequelizeコネクションを先に閉じてから新しいものを作成していたため、その間のリクエストが `ConnectionManager.getConnection was called after the connection manager was closed!` エラーで失敗していた。

## 対策
- 新しいコネクション作成・モデル再バインドを先に行い、その後で古いコネクションを閉じるよう順序を変更

## 効果
- `POST /api/v1/initialize` 直後のリクエスト失敗を解消
- スコアリングツールのユーザーフローテストが安定動作