### PR TITLE
perf: LinkのSPA対応とCrokストリーミング高速化

### DIFF
--- a/application/client/src/components/foundation/Link.tsx
+++ b/application/client/src/components/foundation/Link.tsx
@@ -1,13 +1,34 @@
-import { AnchorHTMLAttributes, forwardRef } from "react";
-import { To, useHref } from "react-router";
+import { AnchorHTMLAttributes, forwardRef, MouseEvent, useCallback } from "react";
+import { To, useHref, useNavigate } from "react-router";
 
 type Props = Omit<AnchorHTMLAttributes<HTMLAnchorElement>, "href"> & {
   to: To;
 };
 
-export const Link = forwardRef<HTMLAnchorElement, Props>(({ to, ...props }, ref) => {
+export const Link = forwardRef<HTMLAnchorElement, Props>(({ to, onClick, ...props }, ref) => {
   const href = useHref(to);
-  return <a ref={ref} href={href} {...props} />;
+  const navigate = useNavigate();
+
+  const handleClick = useCallback(
+    (e: MouseEvent<HTMLAnchorElement>) => {
+      onClick?.(e);
+      if (
+        e.defaultPrevented ||
+        e.button !== 0 ||
+        e.metaKey ||
+        e.altKey ||
+        e.ctrlKey ||
+        e.shiftKey
+      ) {
+        return;
+      }
+      e.preventDefault();
+      navigate(to);
+    },
+    [navigate, to, onClick],
+  );
+
+  return <a ref={ref} href={href} onClick={handleClick} {...props} />;
 });
 
 Link.displayName = "Link";

--- a/application/server/src/routes/api/crok.ts
+++ b/application/server/src/routes/api/crok.ts
@@ -21,6 +21,8 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+const CHUNK_SIZE = 5;
+
 crokRouter.get("/crok", async (req, res) => {
   if (req.session.userId === undefined) {
     throw new httpErrors.Unauthorized();
@@ -33,16 +35,15 @@ crokRouter.get("/crok", async (req, res) => {
 
   let messageId = 0;
 
-  // TTFT (Time to First Token)
-  await sleep(3000);
-
-  for (const char of response) {
+  const chars = [...response];
+  for (let i = 0; i < chars.length; i += CHUNK_SIZE) {
     if (res.closed) break;
 
-    const data = JSON.stringify({ text: char, done: false });
+    const chunk = chars.slice(i, i + CHUNK_SIZE).join("");
+    const data = JSON.stringify({ text: chunk, done: false });
     res.write(`event: message\nid: ${messageId++}\ndata: ${data}\n\n`);
 
-    await sleep(10);
+    await sleep(1);
   }
 
   if (!res.closed) {


### PR DESCRIPTION
## ボトルネック
- `<a>` タグがフルページリロードを行い、ナビゲーション時に認証状態がロストしていた
- Crok APIに不要な3秒の `sleep` が存在し、TTFT（Time To First Token）を遅延させていた
- SSEチャンク送信が1文字ずつ `sleep(10ms)` で、レスポンス表示が遅かった

## 対策
- Link コンポーネントを React Router の `useNavigate` によるclient-side navigationに変更
- Crok APIの3秒 `sleep` を削除
- SSEチャンク送信を5文字チャンク `sleep(1ms)` に変更

## 効果
- 全ページのナビゲーションがSPA遷移になり、認証状態が維持される
- Crokチャットのレスポンス開始が3秒早くなり、表示速度も大幅向上