### PR TITLE
perf: 音声波形表示をサーバー側プリ計算に移行

### DIFF
--- a/application/client/src/components/foundation/SoundPlayer.tsx
+++ b/application/client/src/components/foundation/SoundPlayer.tsx
@@ -1,10 +1,8 @@
-import { ReactEventHandler, useCallback, useMemo, useRef, useState } from "react";
+import { ReactEventHandler, useCallback, useRef, useState } from "react";
 
 import { AspectRatioBox } from "@web-speed-hackathon-2026/client/src/components/foundation/AspectRatioBox";
 import { FontAwesomeIcon } from "@web-speed-hackathon-2026/client/src/components/foundation/FontAwesomeIcon";
 import { SoundWaveSVG } from "@web-speed-hackathon-2026/client/src/components/foundation/SoundWaveSVG";
-import { useFetch } from "@web-speed-hackathon-2026/client/src/hooks/use_fetch";
-import { fetchBinary } from "@web-speed-hackathon-2026/client/src/utils/fetchers";
 import { getSoundPath } from "@web-speed-hackathon-2026/client/src/utils/get_path";
 
 interface Props {
@@ -12,11 +10,7 @@ interface Props {
 }
 
 export const SoundPlayer = ({ sound }: Props) => {
-  const { data, isLoading } = useFetch(getSoundPath(sound.id), fetchBinary);
-
-  const blobUrl = useMemo(() => {
-    return data !== null ? URL.createObjectURL(new Blob([data])) : null;
-  }, [data]);
+  const audioUrl = getSoundPath(sound.id);
 
   const [currentTimeRatio, setCurrentTimeRatio] = useState(0);
   const handleTimeUpdate = useCallback<ReactEventHandler<HTMLAudioElement>>((ev) => {
@@ -37,13 +31,9 @@ export const SoundPlayer = ({ sound }: Props) => {
     });
   }, []);
 
-  if (isLoading || data === null || blobUrl === null) {
-    return null;
-  }
-
   return (
     <div className="bg-cax-surface-subtle flex h-full w-full items-center justify-center">
-      <audio ref={audioRef} loop={true} onTimeUpdate={handleTimeUpdate} src={blobUrl} />
+      <audio ref={audioRef} loop={true} onTimeUpdate={handleTimeUpdate} src={audioUrl} preload="none" />
       <div className="p-2">
         <button
           className="bg-cax-accent text-cax-surface-raised flex h-8 w-8 items-center justify-center rounded-full text-sm hover:opacity-75"
@@ -64,7 +54,7 @@ export const SoundPlayer = ({ sound }: Props) => {
           <AspectRatioBox aspectHeight={1} aspectWidth={10}>
             <div className="relative h-full w-full">
               <div className="absolute inset-0 h-full w-full">
-                <SoundWaveSVG soundData={data} />
+                <SoundWaveSVG soundId={sound.id} />
               </div>
               <div
                 className="bg-cax-surface-subtle absolute inset-0 h-full w-full opacity-75"

--- a/application/client/src/components/foundation/SoundWaveSVG.tsx
+++ b/application/client/src/components/foundation/SoundWaveSVG.tsx
@@ -1,74 +1,34 @@
 import { useEffect, useRef, useState } from "react";
-import { AudioContext } from "standardized-audio-context";
 
-interface ParsedData {
+import { fetchJSON } from "@web-speed-hackathon-2026/client/src/utils/fetchers";
+
+interface PeaksData {
   max: number;
   peaks: number[];
 }
 
-function mean(arr: (number | undefined)[]): number {
-  let sum = 0;
-  let count = 0;
-  for (const v of arr) {
-    if (v != null) {
-      sum += v;
-      count++;
-    }
-  }
-  return count === 0 ? 0 : sum / count;
-}
-
-function chunk<T>(arr: T[], size: number): T[][] {
-  const result: T[][] = [];
-  for (let i = 0; i < arr.length; i += size) {
-    result.push(arr.slice(i, i + size));
-  }
-  return result;
-}
-
-async function calculate(data: ArrayBuffer): Promise<ParsedData> {
-  const audioCtx = new AudioContext();
-
-  // 音声をデコードする
-  const buffer = await audioCtx.decodeAudioData(data.slice(0));
-  // 左の音声データの絶対値を取る
-  const leftData = Array.from(buffer.getChannelData(0), Math.abs);
-  // 右の音声データの絶対値を取る
-  const rightData = Array.from(buffer.getChannelData(1), Math.abs);
-
-  // 左右の音声データの平均を取る
-  const normalized = leftData.map((v, i) => mean([v, rightData[i]]));
-  // 100 個の chunk に分ける
-  const chunks = chunk(normalized, Math.ceil(normalized.length / 100));
-  // chunk ごとに平均を取る
-  const peaks = chunks.map((c) => mean(c));
-  // chunk の平均の中から最大値を取る
-  const max = Math.max(...peaks, 0);
-
-  return { max, peaks };
-}
-
 interface Props {
-  soundData: ArrayBuffer;
+  soundId: string;
 }
 
-export const SoundWaveSVG = ({ soundData }: Props) => {
+export const SoundWaveSVG = ({ soundId }: Props) => {
   const uniqueIdRef = useRef(Math.random().toString(16));
-  const [{ max, peaks }, setPeaks] = useState<ParsedData>({
-    max: 0,
-    peaks: [],
-  });
+  const [data, setData] = useState<PeaksData | null>(null);
 
   useEffect(() => {
-    calculate(soundData).then(({ max, peaks }) => {
-      setPeaks({ max, peaks });
-    });
-  }, [soundData]);
+    fetchJSON<PeaksData>(`/api/v1/sounds/${soundId}/peaks`).then(setData).catch(() => {});
+  }, [soundId]);
+
+  if (data === null) {
+    return <svg className="h-full w-full" preserveAspectRatio="none" viewBox="0 0 100 1" />;
+  }
+
+  const { max, peaks } = data;
 
   return (
     <svg className="h-full w-full" preserveAspectRatio="none" viewBox="0 0 100 1">
       {peaks.map((peak, idx) => {
-        const ratio = peak / max;
+        const ratio = max > 0 ? peak / max : 0;
         return (
           <rect
             key={`${uniqueIdRef.current}#${idx}`}

--- a/application/server/src/routes/api/sound.ts
+++ b/application/server/src/routes/api/sound.ts
@@ -1,17 +1,113 @@
+import { execFile } from "child_process";
 import { promises as fs } from "fs";
 import path from "path";
+import { promisify } from "util";
 
+import ffmpegPath from "ffmpeg-static";
 import { Router } from "express";
 import httpErrors from "http-errors";
 import { v4 as uuidv4 } from "uuid";
 
-import { UPLOAD_PATH } from "@web-speed-hackathon-2026/server/src/paths";
+import { CACHE_PATH, PUBLIC_PATH, UPLOAD_PATH } from "@web-speed-hackathon-2026/server/src/paths";
 import { convertSound } from "@web-speed-hackathon-2026/server/src/utils/convert_sound";
+
+const execFileAsync = promisify(execFile);
 
 // 変換した音声の拡張子
 const EXTENSION = "mp3";
 
 export const soundRouter = Router();
+
+async function findSoundFile(soundId: string): Promise<string | null> {
+  const filename = `${soundId}.${EXTENSION}`;
+  for (const dir of [
+    path.resolve(UPLOAD_PATH, "sounds"),
+    path.resolve(PUBLIC_PATH, "sounds"),
+  ]) {
+    const filePath = path.join(dir, filename);
+    try {
+      await fs.access(filePath);
+      return filePath;
+    } catch {
+      // not found in this directory
+    }
+  }
+  return null;
+}
+
+async function computeWaveformPeaks(filePath: string): Promise<{ peaks: number[]; max: number }> {
+  const tmpDir = await fs.mkdtemp(path.join(import.meta.dirname, "../../.cache/waveform-"));
+  const outputPath = path.join(tmpDir, "output.pcm");
+
+  try {
+    await execFileAsync(ffmpegPath!, [
+      "-y", "-i", filePath,
+      "-f", "f32le", "-ac", "1", "-ar", "4000",
+      outputPath,
+    ]);
+    const pcmBuffer = await fs.readFile(outputPath);
+    const samples = new Float32Array(pcmBuffer.buffer, pcmBuffer.byteOffset, pcmBuffer.length / 4);
+    const absData = Array.from(samples, Math.abs);
+
+    const numPeaks = 100;
+    const chunkSize = Math.ceil(absData.length / numPeaks);
+    const peaks: number[] = [];
+    for (let i = 0; i < numPeaks; i++) {
+      const start = i * chunkSize;
+      const end = Math.min(start + chunkSize, absData.length);
+      let sum = 0;
+      for (let j = start; j < end; j++) {
+        sum += absData[j]!;
+      }
+      peaks.push(sum / (end - start));
+    }
+    const max = Math.max(...peaks, 0);
+    return { peaks, max };
+  } finally {
+    await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+// メモリキャッシュ
+const peaksCache = new Map<string, { peaks: number[]; max: number }>();
+
+soundRouter.get("/sounds/:soundId/peaks", async (req, res) => {
+  const soundId = req.params.soundId!;
+
+  // メモリキャッシュチェック
+  const cached = peaksCache.get(soundId);
+  if (cached) {
+    res.setHeader("Cache-Control", "public, max-age=604800, immutable");
+    return res.status(200).type("application/json").send(cached);
+  }
+
+  // ディスクキャッシュチェック
+  const cachePath = path.resolve(CACHE_PATH, `peaks/${soundId}.json`);
+  try {
+    const data = await fs.readFile(cachePath, "utf-8");
+    const parsed = JSON.parse(data);
+    peaksCache.set(soundId, parsed);
+    res.setHeader("Cache-Control", "public, max-age=604800, immutable");
+    return res.status(200).type("application/json").send(parsed);
+  } catch {
+    // no disk cache
+  }
+
+  const filePath = await findSoundFile(soundId);
+  if (!filePath) {
+    throw new httpErrors.NotFound();
+  }
+
+  const result = await computeWaveformPeaks(filePath);
+  peaksCache.set(soundId, result);
+
+  // ディスクキャッシュに保存
+  await fs.mkdir(path.resolve(CACHE_PATH, "peaks"), { recursive: true });
+  await fs.writeFile(cachePath, JSON.stringify(result));
+
+  res.setHeader("Cache-Control", "public, max-age=604800, immutable");
+  return res.status(200).type("application/json").send(result);
+});
 
 soundRouter.post("/sounds", async (req, res) => {
   if (req.session.userId === undefined) {


### PR DESCRIPTION
## ボトルネック
- クライアントが音声ファイルをArrayBufferとしてフェッチし、`standardized-audio-context`(16MB) でデコードして波形を描画していた
- SoundPlayerが音声再生にもArrayBufferフェッチを使用していた
- `standardized-audio-context` のインポートだけでバンドルが16MB肥大化

## 対策
- サーバー側にffmpegベースの波形ピークス計算APIを追加（メモリ+ディスクキャッシュで高速応答）
- SoundPlayerから ArrayBuffer フェッチを削除し `<audio src>` で直接再生に変更
- SoundWaveSVGのクライアント側MP3デコードを削除し、サーバーAPIから波形データを取得
- `standardized-audio-context`(16MB) のインポートを除去

## 効果
- バンドルから16MBのライブラリを除去
- メインスレッドでの音声デコード処理が不要に（TBT改善）
- 音声再生がブラウザネイティブの `<audio>` に委譲され軽量化