### PR TITLE
fix: waveform一時ディレクトリ作成前にCACHE_PATHのmkdirを追加

### DIFF
--- a/application/server/src/routes/api/sound.ts
+++ b/application/server/src/routes/api/sound.ts
@@ -36,7 +36,8 @@ async function findSoundFile(soundId: string): Promise<string | null> {
 }
 
 async function computeWaveformPeaks(filePath: string): Promise<{ peaks: number[]; max: number }> {
-  const tmpDir = await fs.mkdtemp(path.join(import.meta.dirname, "../../.cache/waveform-"));
+  await fs.mkdir(CACHE_PATH, { recursive: true });
+  const tmpDir = await fs.mkdtemp(path.join(CACHE_PATH, "waveform-"));
   const outputPath = path.join(tmpDir, "output.pcm");
 
   try {


### PR DESCRIPTION
## ボトルネック
Fly.io環境で `/app/.cache/` ディレクトリが存在せず、波形データのキャッシュ用一時ディレクトリ作成（`mkdtemp`）が ENOENT エラーで失敗していた。

## 対策
- `mkdtemp` の前に `CACHE_PATH` の `mkdir -p` 相当の処理を追加し、親ディレクトリを事前に作成

## 効果
- Fly.io本番環境で音声波形APIが正常に動作するようになった