### PR TITLE
perf: NLP処理サーバーサイド移行・画像alt修正・DM送信修正

### DIFF
--- a/application/client/src/containers/DirectMessageContainer.tsx
+++ b/application/client/src/containers/DirectMessageContainer.tsx
@@ -68,7 +68,7 @@ export const DirectMessageContainer = ({ activeUser, authModalId }: Props) => {
         await sendJSON(`/api/v1/dm/${conversationId}/messages`, {
           body: params.body,
         });
-        loadConversation();
+        await loadConversation();
       } finally {
         setIsSubmitting(false);
       }

--- a/application/e2e/src/home.test.ts
+++ b/application/e2e/src/home.test.ts
@@ -53,7 +53,9 @@ test.describe("ホーム", () => {
   test("投稿クリック → 投稿詳細に遷移する", async ({ page }) => {
     const firstArticle = page.locator("article").first();
     await expect(firstArticle).toBeVisible({ timeout: 30_000 });
-    await firstArticle.click();
+    // 記事中央をクリックすると動画プレイヤーのボタンに当たるため、日時リンクをクリックする
+    const postLink = firstArticle.locator("a time").first();
+    await postLink.click({ timeout: 30_000 });
     await page.waitForURL("**/posts/*", { timeout: 30_000 });
     expect(page.url()).toMatch(/\/posts\/[a-zA-Z0-9-]+/);
   });

--- a/application/e2e/src/post-detail.test.ts
+++ b/application/e2e/src/post-detail.test.ts
@@ -11,7 +11,8 @@ test.describe("投稿詳細", () => {
     await page.goto("/");
     const firstArticle = page.locator("article").first();
     await expect(firstArticle).toBeVisible({ timeout: 30_000 });
-    await firstArticle.click();
+    // 記事中央をクリックすると動画プレイヤーのボタンに当たるため、日時リンクをクリックする
+    await firstArticle.locator("a time").first().click({ timeout: 30_000 });
     await page.waitForURL("**/posts/*", { timeout: 30_000 });
 
     const article = page.locator("article").first();
@@ -29,7 +30,7 @@ test.describe("投稿詳細", () => {
     await page.goto("/");
     const firstArticle = page.locator("article").first();
     await expect(firstArticle).toBeVisible({ timeout: 30_000 });
-    await firstArticle.click();
+    await firstArticle.locator("a time").first().click({ timeout: 30_000 });
     await page.waitForURL("**/posts/*", { timeout: 30_000 });
 
     await expect(page).toHaveTitle(/さんのつぶやき - CaX/, { timeout: 30_000 });
@@ -107,7 +108,7 @@ test.describe("投稿詳細 - 写真", () => {
     await page.goto("/");
     const imageArticle = page.locator("article:has(.grid img)").first();
     await expect(imageArticle).toBeVisible({ timeout: 30_000 });
-    await imageArticle.click();
+    await imageArticle.locator("a time").first().click({ timeout: 30_000 });
     await page.waitForURL("**/posts/*", { timeout: 30_000 });
 
     const coveredImage = page.locator(".grid img").first();

--- a/application/e2e/src/posting.test.ts
+++ b/application/e2e/src/posting.test.ts
@@ -45,7 +45,7 @@ test.describe("投稿機能", () => {
 
     const textarea = page.getByPlaceholder("いまなにしてる？");
     await expect(textarea).toBeVisible({ timeout: 30_000 });
-    await textarea.fill(postText);
+    await textarea.pressSequentially(postText, { delay: 10 });
 
     // 画像ファイルを添付
     const fileInput = page.locator('input[type="file"][accept="image/*"]');
@@ -55,8 +55,10 @@ test.describe("投稿機能", () => {
     );
     await fileInput.setInputFiles(imagePath);
 
-    // モーダル内の投稿ボタンをクリック
-    await page.locator("dialog").getByRole("button", { name: "投稿する" }).click();
+    // 画像処理完了を待ってからモーダル内の投稿ボタンをクリック
+    const submitButton = page.locator("dialog").getByRole("button", { name: "投稿する" });
+    await expect(submitButton).toBeEnabled({ timeout: 60_000 });
+    await submitButton.click();
 
     // 投稿詳細に遷移する
     await page.waitForURL("**/posts/*", { timeout: 60_000 });

--- a/application/server/src/utils/convert_image.ts
+++ b/application/server/src/utils/convert_image.ts
@@ -6,6 +6,41 @@ interface ConvertImageResult {
   alt: string;
 }
 
+function readTiffImageDescription(buf: Buffer): string | undefined {
+  if (buf.length < 8) return undefined;
+
+  const byteOrder = buf.readUInt16BE(0);
+  if (byteOrder !== 0x4949 && byteOrder !== 0x4d4d) return undefined;
+
+  const isBE = byteOrder === 0x4d4d;
+  const readU16 = (offset: number) => (isBE ? buf.readUInt16BE(offset) : buf.readUInt16LE(offset));
+  const readU32 = (offset: number) => (isBE ? buf.readUInt32BE(offset) : buf.readUInt32LE(offset));
+
+  if (readU16(2) !== 42) return undefined;
+
+  const ifdOffset = readU32(4);
+  if (ifdOffset + 2 > buf.length) return undefined;
+
+  const numEntries = readU16(ifdOffset);
+
+  for (let i = 0; i < numEntries; i++) {
+    const entryOffset = ifdOffset + 2 + i * 12;
+    if (entryOffset + 12 > buf.length) break;
+
+    const tag = readU16(entryOffset);
+    if (tag === 270) {
+      const count = readU32(entryOffset + 4);
+      if (count <= 4) {
+        return buf.slice(entryOffset + 8, entryOffset + 8 + count - 1).toString("utf8");
+      }
+      const valueOffset = readU32(entryOffset + 8);
+      if (valueOffset + count > buf.length) return undefined;
+      return buf.slice(valueOffset, valueOffset + count - 1).toString("utf8");
+    }
+  }
+  return undefined;
+}
+
 export async function convertImage(input: Buffer): Promise<ConvertImageResult> {
   let imageDescription: string | undefined;
 
@@ -20,6 +55,14 @@ export async function convertImage(input: Buffer): Promise<ConvertImageResult> {
     }
   } catch {
     // ignore EXIF extraction errors
+  }
+
+  if (imageDescription == null) {
+    try {
+      imageDescription = readTiffImageDescription(input);
+    } catch {
+      // ignore TIFF tag extraction errors
+    }
   }
 
   let pipeline = sharp(input).jpeg({ quality: 90 });


### PR DESCRIPTION
## ボトルネック
- TIFF画像のImageDescriptionがEXIFではなくTIFF IFDに格納されており、alt属性が取得できていなかった
- DM送信後の `loadConversation()` に await がなく、メッセージ表示が不確実だった
- e2eテストのクリック対象が不正確で計測が失敗していた

## 対策
- TIFF IFDからImageDescriptionを読み取るよう画像変換処理を修正
- DM送信後の `loadConversation()` に await を追加
- e2eテストのクリック対象を修正

## 効果
- TIFF画像アップロード時にalt属性が正しく設定される
- DM送信後のメッセージ表示が確実になる
- 計測ツールの「ユーザーフロー: 投稿」「ユーザーフロー: DM送信」が計測可能に