### PR TITLE
fix: CrokのMarkdown再マウント問題とDM作成の不要なJOIN除去

### DIFF
--- a/application/client/src/components/crok/MarkdownRenderer.tsx
+++ b/application/client/src/components/crok/MarkdownRenderer.tsx
@@ -14,7 +14,6 @@ export const MarkdownRenderer = ({ content }: Props) => {
   return (
     <Markdown
       components={{ pre: CodeBlock }}
-      key={content}
       rehypePlugins={[rehypeKatex]}
       remarkPlugins={[remarkMath, remarkGfm]}
     >

--- a/application/server/src/routes/api/direct_message.ts
+++ b/application/server/src/routes/api/direct_message.ts
@@ -44,7 +44,7 @@ directMessageRouter.post("/dm", async (req, res) => {
     throw new httpErrors.NotFound();
   }
 
-  const [conversation] = await DirectMessageConversation.findOrCreate({
+  const [conversation] = await DirectMessageConversation.unscoped().findOrCreate({
     where: {
       [Op.or]: [
         { initiatorId: req.session.userId, memberId: peer.id },
@@ -56,7 +56,6 @@ directMessageRouter.post("/dm", async (req, res) => {
       memberId: peer.id,
     },
   });
-  await conversation.reload();
 
   return res.status(200).type("application/json").send(conversation);
 });


### PR DESCRIPTION
## ボトルネック
- MarkdownRenderer に `key={content}` が設定されていたため、SSEストリーミング中にチャンク受信のたびにコンポーネントが完全再マウントされ、見出しがDOMに安定表示されなかった
- `POST /dm` で defaultScope の5テーブルJOINが実行され、さらに不要な `reload()` も呼ばれていた（フロントは `conversation.id` のみ使用）

## 対策
- MarkdownRenderer: `key={content}` を削除し、差分更新に変更
- POST /dm: `unscoped()` で defaultScope の5テーブルJOINをスキップし、不要な `reload()` を削除

## 効果
- SSEストリーミング中のMarkdown表示が安定化（チャンクごとの再マウント消滅）
- DM作成APIの応答高速化（不要なJOINとreloadを排除）